### PR TITLE
support iptables-legacy and ip6tables-legacy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,5 @@ install:
 	cp nfbpf_compile $(INSTALL_DIR)/
 	cp iptables-tracing $(INSTALL_DIR)/iptables-tracing
 	cp iptables-tracing $(INSTALL_DIR)/ip6tables-tracing
+	cp iptables-tracing $(INSTALL_DIR)/iptables-legacy-tracing
+	cp iptables-tracing $(INSTALL_DIR)/ip6tables-legacy-tracing

--- a/iptables-tracing
+++ b/iptables-tracing
@@ -13,7 +13,7 @@ fi
 exec 4<>$LOCK
 echo -e "${GREEN}Use flock: ${LOCK}${NC}"
 
-iptables="${tracing%-tracing}"
+iptables="${0%-tracing}"
 export iptables
 
 bpf_bytecode=$(eval "nfbpf_compile RAW '$@'")

--- a/iptables-tracing
+++ b/iptables-tracing
@@ -13,10 +13,7 @@ fi
 exec 4<>$LOCK
 echo -e "${GREEN}Use flock: ${LOCK}${NC}"
 
-iptables=iptables
-if [[ "$0" == *ip6tables* ]]; then
-    iptables=ip6tables
-fi
+iptables="${tracing%-tracing}"
 export iptables
 
 bpf_bytecode=$(eval "nfbpf_compile RAW '$@'")


### PR DESCRIPTION
In some linux distro, there are two version of iptables, `iptables` and `iptables-legacy`. This pr support `iptables-legacy-tracing` and `ip6tables-legacy-tracing` by replace the `iptables` variable.